### PR TITLE
Revert "Bump nokogiri from 1.10.10 to 1.11.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,18 +120,15 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.4.0)
     minitest (5.14.2)
     multi_json (1.15.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     nio4r (2.5.4)
-    nokogiri (1.11.0)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
-    nokogiri (1.11.0-x86_64-linux)
-      racc (~> 1.4)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.4)
       nokogiri (~> 1.8, >= 1.8.4)
     pg (1.2.3)
@@ -139,7 +136,6 @@ GEM
       nio4r (~> 2.0)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -218,7 +214,6 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Reverts pgengler/caotico#14. nokogiri 1.11.0 requires Ruby 2.5+.